### PR TITLE
Remove npp ver. 6.8.9 (Remove Notepad++ 6.8.9 (removed from site))

### DIFF
--- a/npp.sls
+++ b/npp.sls
@@ -1,13 +1,4 @@
 npp:
-  '6.8.9':
-    full_name: Notepad++
-    installer: 'https://notepad-plus-plus.org/repository/6.x/6.8.9/npp.6.8.9.Installer.exe'
-    install_flags: '/S'
-    uninstaller: '%ProgramFiles(x86)%/Notepad++/uninstall.exe'
-    uninstall_flags: '/S'
-    msiexec: False
-    locale: en_US
-    reboot: False
   '6.8.8':
     full_name: Notepad++
     installer: 'https://notepad-plus-plus.org/repository/6.x/6.8.8/npp.6.8.8.Installer.exe'

--- a/npp_x86.sls
+++ b/npp_x86.sls
@@ -1,13 +1,4 @@
 npp_x86:
-  '6.8.9':
-    full_name: Notepad++
-    installer: 'https://notepad-plus-plus.org/repository/6.x/6.8.9/npp.6.8.9.Installer.exe'
-    install_flags: '/S'
-    uninstaller: '%ProgramFiles%/Notepad++/uninstall.exe'
-    uninstall_flags: '/S'
-    msiexec: False
-    locale: en_US
-    reboot: False
   '6.8.8':
     full_name: Notepad++
     installer: 'https://notepad-plus-plus.org/repository/6.x/6.8.8/npp.6.8.8.Installer.exe'


### PR DESCRIPTION
Removed according to https://notepad-plus-plus.org/news/v6.8.9-has-been-removed.html
