### PR TITLE
Fix ms-vcpp-2010-sp1-mfc-redist

### DIFF
--- a/ms-vcpp-2010-sp1-mfc-redist_x64.sls
+++ b/ms-vcpp-2010-sp1-mfc-redist_x64.sls
@@ -2,9 +2,9 @@ ms-vcpp-2010-sp1-mfc-redist_x64:
   '10.0.40219':
     full_name: 'Microsoft Visual C++ 2010 Redistributable - x64 10.0.40219'
     installer: 'http://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe'
-    install_flags: '/qn /norestart'
+    install_flags: '/q /norestart'
     uninstaller: 'msiexec.exe'
-    uninstall_flags: '/qn /x {1D8E6291-B0D5-35EC-8441-6616F567A0F7} /norestart'
+    uninstall_flags: '/q /x {1D8E6291-B0D5-35EC-8441-6616F567A0F7} /norestart'
     msiexec: False
     locale: en_US
     reboot: False

--- a/ms-vcpp-2010-sp1-mfc-redist_x86.sls
+++ b/ms-vcpp-2010-sp1-mfc-redist_x86.sls
@@ -2,9 +2,9 @@ ms-vcpp-2010-sp1-mfc-redist_x86:
   '10.0.40219':
     full_name: 'Microsoft Visual C++ 2010 Redistributable - x86 10.0.40219'
     installer: 'http://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe'
-    install_flags: '/qn /norestart'
+    install_flags: '/q /norestart'
     uninstaller: 'msiexec.exe'
-    uninstall_flags: '/qn /x {F0C3E5D1-1ADE-321E-8167-68EF0DE699A5} /norestart'
+    uninstall_flags: '/q /x {F0C3E5D1-1ADE-321E-8167-68EF0DE699A5} /norestart'
     msiexec: False
     locale: en_US
     reboot: False


### PR DESCRIPTION
removed the 'n' flag that does not exist for this MS installer (same problem may exist in other versions of this special distributable installer) removed on basis of issue reported here: https://github.com/saltstack/salt-winrepo-ng/issues/453 by @javadevmtl 
